### PR TITLE
Bump gtr to v0.3.0

### DIFF
--- a/Formula/gtr.rb
+++ b/Formula/gtr.rb
@@ -1,8 +1,8 @@
 class Gtr < Formula
   desc "Git worktree helper"
   homepage "https://github.com/ryanwjackson/gtr"
-  url "https://github.com/ryanwjackson/gtr/releases/download/v0.2.0/gtr-v0.2.0.tar.gz"
-  sha256 "37391b6f7aceb2456e9d940fbe78e2df893134c5ff3ee268733b136064492894"
+  url "https://github.com/ryanwjackson/gtr/releases/download/v0.3.0/gtr-v0.3.0.tar.gz"
+  sha256 "2d4f1735a1a7608f408e61860597a24dde605e2cde17acc4e82888ff03dd7cd6"
   license "MIT"
   head "https://github.com/ryanwjackson/gtr.git", branch: "main"
 


### PR DESCRIPTION
Automated bump (dry_run=false): update URL and SHA256 for v0.3.0.