### PR TITLE
Bump gtr to v0.7.2

### DIFF
--- a/Formula/gtr.rb
+++ b/Formula/gtr.rb
@@ -1,8 +1,8 @@
 class Gtr < Formula
   desc "Git worktree helper"
   homepage "https://github.com/ryanwjackson/gtr"
-  url "https://github.com/ryanwjackson/gtr/releases/download/v0.6.0/gtr-v0.6.0.tar.gz"
-  sha256 "71c7c775a94025b5d2c38619a217bbe908eb304bc3f5b370ba6f73e5cb9cba04"
+  url "https://github.com/ryanwjackson/gtr/releases/download/v0.7.2/gtr-v0.7.2.tar.gz"
+  sha256 "c335b700381080e27d9566a4ac4d40070e8a0e0b9d80864fb9bb2116521874e1"
   license "MIT"
   head "https://github.com/ryanwjackson/gtr.git", branch: "main"
 


### PR DESCRIPTION
Automated bump (dry_run=false): update URL and SHA256 for v0.7.2.